### PR TITLE
Add default! to all settings variables

### DIFF
--- a/scss/helper/flexiblegs-settings.scss
+++ b/scss/helper/flexiblegs-settings.scss
@@ -3,16 +3,16 @@
 $flexiblegs-method: (
   "css",
   "bem"
-);
+) !default;
 $flexiblegs-breakpoint: (
   "xl" : "",
   "lg" : "(max-width: 1024px)",
   "md" : "(max-width: 768px)",
   "sm" : "(max-width: 667px)"
-);
+) !default;
 $wrap-col: (
   "auto", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
-);
+) !default;
 $wrap-prop: (
   "table",
   "flexbox",
@@ -28,11 +28,11 @@ $wrap-prop: (
   "baseline",
   "reverse",
   "not-reverse"
-);
+) !default;
 $col-row: (
   1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
-);
-$col-width: ();
+) !default;
+$col-width: () !default;
 $col-prop: (
   "hidden",
   "not-hidden",
@@ -40,13 +40,13 @@ $col-prop: (
   "not-first",
   "last",
   "not-last"
-);
+) !default;
 $wrap-gutter: (
   0, 8, 16, 24, 40
-);
+) !default;
 $wrap-outside: (
   0, 8, 16, 24, 40
-);
+) !default;
 $wrap-masonry: (
   2, 3, 4, 5, 6
-);
+) !default;


### PR DESCRIPTION
Since the load order in `app.scss` is:

```
@import "scss/helper/flexiblegs-settings";
@import "bower_components/flexiblegs-scss/flexiblegs-scss";
@import "scss/helper/flexiblegs-scss-plus";
```

Wouldn't it be more useful to define all variables in `flexiblegs-settings.scss` as `default!` so that the host application could remove/modify these settings?

A few use cases would be:
- I want to change the default breakpoint names / values
- I want to change the row/column numbering
- I need to support IE8, so I want to drop the `flexbox` prop

Just to name a few.
