### PR TITLE
 Device-ready custom CSS settings added

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,68 @@ $wrap-prop: (
 $col-row: (
   1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
 );
-$col-width: ();
+$custom-sizeables: (
+
+	// Single CSS
+	"width" : (
+		(25, 50, 100) : (
+			"width" : %,
+		)
+	),
+	"height" : (
+		(100, 300, 500) : (
+			"height" : px,
+		)
+	),
+
+
+	"fsize" : (
+		(14, 19, 22) : (
+			"font-size" : px
+		)
+	),
+
+	// With value shortcuts
+	"fontsize" : (
+		(
+			"small"  : "0.7",
+			"medium" : "1",
+			"large"  : "1.5"
+		) : (
+			"font-size" : em
+		)
+	),
+
+
+	// Without value suffix
+	"fontweight" : (
+		(normal, bold, 900) : (
+			"font-weight"
+		)
+	),
+
+	"align" : (
+		(left, right, center, justify) : (
+			"text-align",
+		)
+	),
+
+
+	// With multiple CSS
+	"paddingx" : (
+		(0, 8, 16) : (
+			"padding-left" : px,
+			"padding-right" : px
+		)
+	),
+	"marginy" : (
+		(0, 8, 16) : (
+			"margin-top" : px,
+			"margin-bottom" : px
+		)
+	)
+
+);
 $col-prop: (
   "hidden",
   "not-hidden",

--- a/scss/helper/flexiblegs-scss-plus.scss
+++ b/scss/helper/flexiblegs-scss-plus.scss
@@ -243,18 +243,18 @@
           }
         }
       }
-      @each $col-width-val in $col-width {
-        @if $flexiblegs-method-val=="css" {
-          .#{$flexiblegs-breakpoint-key}-width-#{$col-width-val} {
-            @include col("width", $val: $col-width-val);
+	  @each $shortcut, $custom-css-info in $custom-sizeables {
+        @each $values, $custom-csses in $custom-css-info {
+          @each $name, $value in $values {
+		  	@if not $value { $value: $name; }
+            .#{$flexiblegs-breakpoint-key}-#{$shortcut}-#{$name} {
+              @each $custom-css, $suffix in $custom-csses {
+                #{$custom-css}: #{$value}#{$suffix};
+              }
+            }
           }
         }
-        @else if $flexiblegs-method-val=="bem" {
-          .wrap__col--#{$flexiblegs-breakpoint-key}-width-#{$col-width-val} {
-            @include col("width", $val: $col-width-val);
-          }
-        }
-      }
+	  }
       @each $col-prop-val in $col-prop {
         @if $col-prop-val=="hidden" {
           @if $flexiblegs-method-val=="css" {
@@ -594,18 +594,18 @@
             }
           }
         }
-        @each $col-width-val in $col-width {
-          @if $flexiblegs-method-val=="css" {
-            .#{$flexiblegs-breakpoint-key}-width-#{$col-width-val} {
-              @include col("width", $val: $col-width-val);
+	    @each $shortcut, $custom-css-info in $custom-sizeables {
+          @each $values, $custom-csses in $custom-css-info {
+            @each $name, $value in $values {
+	    	  	@if not $value { $value: $name; }
+              .#{$flexiblegs-breakpoint-key}-#{$shortcut}-#{$name} {
+                @each $custom-css, $suffix in $custom-csses {
+                  #{$custom-css}: #{$value}#{$suffix};
+                }
+              }
             }
           }
-          @else if $flexiblegs-method-val=="bem" {
-            .wrap__col--#{$flexiblegs-breakpoint-key}-width-#{$col-width-val} {
-              @include col("width", $val: $col-width-val);
-            }
-          }
-        }
+	    }
         @each $col-prop-val in $col-prop {
           @if $col-prop-val=="hidden" {
             @if $flexiblegs-method-val=="css" {

--- a/scss/helper/flexiblegs-settings.scss
+++ b/scss/helper/flexiblegs-settings.scss
@@ -32,7 +32,68 @@ $wrap-prop: (
 $col-row: (
   1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
 );
-$col-width: ();
+$custom-sizeables: (
+
+	// Single CSS
+	"width" : (
+		(25, 50, 100) : (
+			"width" : %,
+		)
+	),
+	"height" : (
+		(100, 300, 500) : (
+			"height" : px,
+		)
+	),
+
+
+	"fsize" : (
+		(14, 19, 22) : (
+			"font-size" : px
+		)
+	),
+
+	// With value shortcuts
+	"fontsize" : (
+		(
+			"small"  : "0.7",
+			"medium" : "1",
+			"large"  : "1.5"
+		) : (
+			"font-size" : em
+		)
+	),
+
+
+	// Without value suffix
+	"fontweight" : (
+		(normal, bold, 900) : (
+			"font-weight"
+		)
+	),
+
+	"align" : (
+		(left, right, center, justify) : (
+			"text-align",
+		)
+	),
+
+
+	// With multiple CSS
+	"paddingx" : (
+		(0, 8, 16) : (
+			"padding-left" : px,
+			"padding-right" : px
+		)
+	),
+	"marginy" : (
+		(0, 8, 16) : (
+			"margin-top" : px,
+			"margin-bottom" : px
+		)
+	)
+
+);
 $col-prop: (
   "hidden",
   "not-hidden",


### PR DESCRIPTION
This is an enhancement to increase Flexible Grid System's flexibility on other CSS codes. Everyone will be able to add their custom CSS shortcuts within the predefined Flexible Grid System screen breakpoints. (Inspired by [PixelPerfect CSS](https://github.com/pixelperfectcss/pixelperfectcss-scss))

## USAGE
![flexible-custom](https://user-images.githubusercontent.com/12401765/32789906-ffa295ac-c96d-11e7-9ef3-7faf802d6041.jpg)